### PR TITLE
Include no-symlinks in pub get

### DIFF
--- a/tool/build.dart
+++ b/tool/build.dart
@@ -270,7 +270,9 @@ _main(List<String> argv) async {
       }
       // Dart Link.
     } else if (linkType == "Dart") {
-      var pur = await exec("pub", args: ["get"], writeToBuffer: true);
+      var pur = await exec("pub",
+          args: ["get", "--no-package-symlinks"],
+          writeToBuffer: true);
       if (pur.exitCode != 0) {
         await fail("DSLink ${name}: Failed to fetch dependencies.\n${pur.output}");
       }


### PR DESCRIPTION
Later dart versions do this automatically. Current build does not.
This is needed because when a packages directory exists, it will try to use that instead of the .packages file for mapping dependencies.