### PR TITLE
Make it much easier to use the link builder as a standalone tool.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ tmp/
 .DS_Store
 files/*
 !files/.gitkeep
+*-override/
+*-override.json

--- a/data/links/dslink-dart-digital-ocean.json
+++ b/data/links/dslink-dart-digital-ocean.json
@@ -3,7 +3,8 @@
   "displayName": "Digital Ocean",
   "type": "Dart",
   "automated": {
-    "repository": "https://github.com/IOT-DSA/dslink-dart-digital-ocean.git"
+    "repository": "https://github.com/IOT-DSA/dslink-dart-digital-ocean.git",
+    "ignoreBuildScript": true
   },
   "description": "Create, manage, and monitor Digital Ocean droplets",
   "category": "Data Acquisition"

--- a/data/links/dslink-dart-dql.json
+++ b/data/links/dslink-dart-dql.json
@@ -4,7 +4,8 @@
   "displayName": "DQL",
   "type": "Dart",
   "automated": {
-    "repository": "https://github.com/IOT-DSA/dslink-dart-dql.git"
+    "repository": "https://github.com/IOT-DSA/dslink-dart-dql.git",
+    "ignoreBuildScript": true
   },
   "description": "Run Queries against DSA",
   "category": "Data Acquisition"

--- a/data/links/dslink-dart-elios4you.json
+++ b/data/links/dslink-dart-elios4you.json
@@ -3,7 +3,8 @@
   "displayName": "Elios4You",
   "type": "Dart",
   "automated": {
-    "repository": "https://github.com/IOT-DSA/dslink-dart-elios4you.git"
+    "repository": "https://github.com/IOT-DSA/dslink-dart-elios4you.git",
+    "ignoreBuildScript": true
   },
   "description": "Receive Data from Elios4You",
   "category": "Data Acquisition"

--- a/data/links/dslink-dart-rest.json
+++ b/data/links/dslink-dart-rest.json
@@ -3,7 +3,8 @@
   "displayName": "REST Server",
   "type": "Dart",
   "automated": {
-    "repository": "https://github.com/IOT-DSA/dslink-dart-rest.git"
+    "repository": "https://github.com/IOT-DSA/dslink-dart-rest.git",
+    "ignoreBuildScript": true
   },
   "description": "Use a REST API to manipulate custom nodes",
   "category": "Data Acquisition"

--- a/data/links/dslink-dart-schedule.json
+++ b/data/links/dslink-dart-schedule.json
@@ -3,7 +3,8 @@
   "displayName": "Schedule",
   "type": "Dart",
   "automated": {
-    "repository": "https://github.com/IOT-DSA/dslink-dart-schedule.git"
+    "repository": "https://github.com/IOT-DSA/dslink-dart-schedule.git",
+    "ignoreBuildScript": true
   },
   "description": "Create and Manage Value Schedules",
   "category": "Scheduling"

--- a/tool/util.dart
+++ b/tool/util.dart
@@ -21,5 +21,7 @@ part "util/links.dart";
 
 String uuid;
 String fileUuid;
+String currentLinkDisplayName;
+String currentLinkBuild;
 DateTime buildTimestamp;
 List<String> gargv;

--- a/tool/util.dart
+++ b/tool/util.dart
@@ -25,3 +25,7 @@ String currentLinkDisplayName;
 String currentLinkBuild;
 DateTime buildTimestamp;
 List<String> gargv;
+
+bool isOptionOn(String name) =>
+  gargv != null && gargv.contains("--${name}");
+bool get isDebugOn => isOptionOn("debug");

--- a/tool/util/execute.dart
+++ b/tool/util/execute.dart
@@ -13,19 +13,19 @@ class BetterProcessResult extends ProcessResult {
 Future<BetterProcessResult> exec(
   String executable,
   {
-  List<String> args: const [],
-  String workingDirectory,
-  Map<String, String> environment,
-  bool includeParentEnvironment: true,
-  bool runInShell: false,
-  stdin,
-  ProcessHandler handler,
-  OutputHandler stdoutHandler,
-  OutputHandler stderrHandler,
-  OutputHandler outputHandler,
-  File outputFile,
-  bool inherit: false,
-  bool writeToBuffer: false
+    List<String> args: const [],
+    String workingDirectory,
+    Map<String, String> environment,
+    bool includeParentEnvironment: true,
+    bool runInShell: false,
+    stdin,
+    ProcessHandler handler,
+    OutputHandler stdoutHandler,
+    OutputHandler stderrHandler,
+    OutputHandler outputHandler,
+    File outputFile,
+    bool inherit: false,
+    bool writeToBuffer: false
   }) async {
   IOSink raf;
 
@@ -47,12 +47,14 @@ Future<BetterProcessResult> exec(
       runInShell: runInShell
     );
 
+    var startMessage = "== Executing ${executable}"
+      " with arguments ${args} (pid: ${process.pid}) ==";
+
     if (raf != null) {
-      await raf.writeln(
-        "[${currentTimestamp}] == Executing ${executable}"
-          " with arguments ${args} (pid: ${process.pid}) =="
-      );
+      await raf.writeln("[${currentTimestamp}] ${startMessage}");
     }
+
+    dbg(startMessage);
 
     var buff = new StringBuffer();
     var ob = new StringBuffer();
@@ -79,6 +81,8 @@ Future<BetterProcessResult> exec(
       if (raf != null) {
         await raf.writeln("[${currentTimestamp}] ${str}");
       }
+
+      dbg("${str}");
     });
 
     process.stderr.transform(UTF8.decoder).listen((str) async {
@@ -102,6 +106,8 @@ Future<BetterProcessResult> exec(
       if (raf != null) {
         await raf.writeln("[${currentTimestamp}] ${str}");
       }
+
+      dbg("${str}");
     });
 
     if (handler != null) {
@@ -123,10 +129,12 @@ Future<BetterProcessResult> exec(
     var pid = process.pid;
 
     if (raf != null) {
-      await raf.writeln("[${currentTimestamp}] == Exited with status ${code} ==");
+      await raf.writeln("${currentTimestamp} == Exited with status ${code} ==");
       await raf.flush();
       await raf.close();
     }
+
+    dbg("== Exited with status ${code} ==");
 
     return new BetterProcessResult(
       pid,

--- a/tool/util/fs.dart
+++ b/tool/util/fs.dart
@@ -11,18 +11,36 @@ pushd(String path) async {
   if (!(await dir.exists())) {
     await dir.create(recursive: true);
   }
-  Directory.current = dir;
+  cd(dir.path);
 }
 
-Future<dynamic> readJsonFile(String path, [defaultValue]) async {
+Future<dynamic> readJsonFile(String path, {defaultValue, String shadow}) async {
   var file = new File(path);
+  var shadowFile = shadow is String ? new File(shadow) : null;
+
+  Future<dynamic> handleShadow(dynamic input) async {
+    if (shadowFile == null || !(await shadowFile.exists())) {
+      return input;
+    }
+
+    if (input is! Map) {
+      return input;
+    }
+
+    var shadowContent = await shadowFile.readAsString();
+    var json = JSON.decode(shadowContent);
+    var result = merge(input, json, allowDirectives: true);
+    dbg("[Load Shadow JSON] ${path}");
+    return result;
+  }
 
   if (!(await file.exists()) && defaultValue != null) {
-    return defaultValue;
+    return await handleShadow(defaultValue);
   }
 
   var content = await file.readAsString();
-  return JSON.decode(content);
+  dbg("[Load JSON] ${path}");
+  return await handleShadow(JSON.decode(content));
 }
 
 Future saveJsonFile(String path, value) async {
@@ -30,11 +48,14 @@ Future saveJsonFile(String path, value) async {
   await file.create(recursive: true);
   var content = const JsonEncoder.withIndent("  ").convert(value);
   await file.writeAsString(content + "\n");
+
+  dbg("[Write JSON] ${path}");
 }
 
 void cd(String path) {
   var dir = new Directory(path);
   Directory.current = dir;
+  dbg("[Change Directory] ${path}");
 }
 
 Future makeZipFile(String target) async {
@@ -55,6 +76,8 @@ Future makeZipFile(String target) async {
   if (result.exitCode != 0) {
     throw new Exception("Failed to make ZIP file!");
   }
+
+  dbg("[Create ZIP] ${target}");
 }
 
 void popd() {
@@ -62,13 +85,14 @@ void popd() {
     throw new Exception("No Directory to Pop from the Stack");
   }
 
-  Directory.current = _dirStack.removeLast();
+  cd(_dirStack.removeLast().path);
 }
 
 ensureDirectory(String path) async {
   var dir = new Directory(path);
   if (!(await dir.exists())) {
     await dir.create(recursive: true);
+    dbg("[Make Directory] ${path}");
   }
 }
 
@@ -78,6 +102,7 @@ rmkdir(String path) async {
     await dir.delete(recursive: true);
   }
   await dir.create(recursive: true);
+  dbg("[Make Directory] ${path}");
 }
 
 Future<File> copy(String from, String to) async {
@@ -87,6 +112,8 @@ Future<File> copy(String from, String to) async {
   if (!(await tf.exists())) {
     await tf.create(recursive: true);
   }
+
+  dbg("[Copy] ${from} => ${to}");
 
   return await ff.copy(tf.path);
 }

--- a/tool/util/fs.dart
+++ b/tool/util/fs.dart
@@ -29,7 +29,7 @@ Future<dynamic> readJsonFile(String path, {defaultValue, String shadow}) async {
 
     var shadowContent = await shadowFile.readAsString();
     var json = JSON.decode(shadowContent);
-    var result = merge(input, json, allowDirectives: true);
+    var result = merge(json, input, allowDirectives: true);
     dbg("[Load Shadow JSON] ${path}");
     return result;
   }

--- a/tool/util/json.dart
+++ b/tool/util/json.dart
@@ -18,8 +18,12 @@ Future<List<dynamic>> loadJsonDirectoryList(String path, {
     if (entity is! File) continue;
     if (!entity.path.endsWith(".json")) continue;
 
+    var name = entity.path.split("/").last;
     doWork() async {
-      var data = await readJsonFile(entity.path);
+      var data = await readJsonFile(
+        entity.path,
+        shadow: "${path}-override/${name}"
+      );
       out.add(data);
     }
 
@@ -165,8 +169,9 @@ Map merge(Map a, Map b, {
   for (var key in b.keys) {
     var value = b[key];
 
-    if (allowDirectives && key is String && key.endsWith("!remove"))
+    if (allowDirectives && key is String && key.endsWith("!remove")) {
       continue;
+    }
 
     if (!a.containsKey(key)) {
       out[key] = value;

--- a/tool/util/lifecycle.dart
+++ b/tool/util/lifecycle.dart
@@ -1,11 +1,7 @@
 part of dsa.links.repository.util;
 
 dbg(String msg) {
-  if (gargv == null) {
-    return;
-  }
-
-  if (gargv.contains("--debug")) {
+  if (isDebugOn) {
     var prefix = "[DEBUG]";
     if (currentLinkBuild != null) {
       prefix += "[${currentLinkDisplayName}]";
@@ -23,13 +19,13 @@ dbg(String msg) {
 }
 
 fail(String msg, {String out, bool firstLineOnlyDebug: false}) async {
-  if (firstLineOnlyDebug) {
+  if (firstLineOnlyDebug && isDebugOn) {
     msg = msg.split("\n").first;
   }
 
   print("[ERROR] ${msg}");
 
-  if (gargv != null && gargv.contains("--test")) {
+  if (isOptionOn("test")) {
     exit(1);
   }
 

--- a/tool/util/lifecycle.dart
+++ b/tool/util/lifecycle.dart
@@ -1,7 +1,37 @@
 part of dsa.links.repository.util;
 
-fail(String msg, {String out}) async {
-  print("ERROR: ${msg}");
+dbg(String msg) {
+  if (gargv == null) {
+    return;
+  }
+
+  if (gargv.contains("--debug")) {
+    var prefix = "[DEBUG]";
+    if (currentLinkBuild != null) {
+      prefix += "[${currentLinkDisplayName}]";
+    }
+    var lines = msg.trim().split("\n");
+    for (var line in lines) {
+      line = line.trim();
+      if (line.isEmpty || line == ".") {
+        continue;
+      }
+
+      print("${prefix} ${line}");
+    }
+  }
+}
+
+fail(String msg, {String out, bool firstLineOnlyDebug: false}) async {
+  if (firstLineOnlyDebug) {
+    msg = msg.split("\n").first;
+  }
+
+  print("[ERROR] ${msg}");
+
+  if (gargv != null && gargv.contains("--test")) {
+    exit(1);
+  }
 
   var m = new StringBuffer();
   m.writeln("*Build Failed:*");

--- a/tool/util/links.dart
+++ b/tool/util/links.dart
@@ -2,9 +2,13 @@ part of dsa.links.repository.util;
 
 Future<List<Map<String, dynamic>>> buildLinksList() async {
   var links = await loadJsonDirectoryList("data/links");
+
   var typeRules = await loadJsonDirectoryMap("data/types");
   var mixins = await loadJsonDirectoryMap("data/mixins");
-  var config = await readJsonFile("data/config.json");
+  var config = await readJsonFile(
+    "data/config.json",
+    shadow: "data/config-override.json"
+  );
 
   for (Map l in links) {
     mergeConfigurationTypes(typeRules, "type", l);


### PR DESCRIPTION
From time to time, it might be needed to use the link builder for standalone uses, such as building packages to be uploaded to a production server without internet. The following changes have been made:

- Fix any broken link builds (mostly Dart links that had old build scripts, added ignoreBuildScript: true)
- Add a `--debug` command line flag that shows debug messages.
- Add a `--continue={some-link-name}` that will start the build from that point (useful for debugging issues)
- Add 'shadow configurations' that can be specified in adjacent directories and files. These files can be used to have local-only configuration changes.
- Allow specifying a Git branch in an automated builder configuration.
